### PR TITLE
Let caddy handle https redirection instead of doing it by ourselves

### DIFF
--- a/Caddyfile.base
+++ b/Caddyfile.base
@@ -18,10 +18,7 @@
 	admin off
 }
 
-{$DOMAIN:localhost}:80 {
-	redir https://{host}{uri} permanent
-}
-
+{$DOMAIN:localhost}:80, 
 {$DOMAIN:localhost}:443 {
 	redir /abc https://example.com
 	@snapshot path_regexp ^/snapshot/(\d\d\d\d-\d\d-\d\d)/(.*)$

--- a/index.test.ts
+++ b/index.test.ts
@@ -20,16 +20,6 @@ const domain = "localhost" as const;
 const delpaGitHubRawBaseUrl =
   "https://raw.githubusercontent.com/delpa-org" as const;
 
-test("Redirect http to https", async () => {
-  const hostAddress = `http://${domain}:3000`;
-  const response = await fetch(`${hostAddress}/some/path`, {
-    redirect: "manual",
-  });
-
-  expect(response.status).toBe(301);
-  expect(response.headers.get("location")).toBe(`https://${domain}/some/path`);
-});
-
 describe("/snapshot", () => {
   const hostAddress = `https://${domain}:3001`;
   const snapshotFirstPathComp = "snapshot" as const;


### PR DESCRIPTION
Caddy automatically redirects to https, if the domain name qualifies.

Some hosting services already lays a front layer with https, which the current configuration would break.

https://caddyserver.com/docs/automatic-https#overview