### PR TITLE
Allow specify host address and don't limit port

### DIFF
--- a/Caddyfile.base
+++ b/Caddyfile.base
@@ -18,8 +18,7 @@
 	admin off
 }
 
-{$DOMAIN:localhost}:80, 
-{$DOMAIN:localhost}:443 {
+{$HOST_ADDRESS:localhost} {
 	redir /abc https://example.com
 	@snapshot path_regexp ^/snapshot/(\d\d\d\d-\d\d-\d\d)/(.*)$
 	redir @snapshot https://raw.githubusercontent.com/delpa-org/melpa-snapshot-{re.1}/refs/heads/master/packages/{re.2} permanent


### PR DESCRIPTION
The user can be more flexible in specifying the host address based on https://caddyserver.com/docs/caddyfile/concepts#addresses

- example.com: both http and https
- http://example.com: http only
- https://example.com: https only

The http-only configuration may be desirable because some host platforms adds an https in front of the server and makes all internal traffic http.