### PR TITLE
Update dependency node to v26.2.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 24.16.0
+          node-version: 26.2.0
           cache: "npm"
 
       - name: Install Dependencies

--- a/.github/workflows/prod_container_img.yml
+++ b/.github/workflows/prod_container_img.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 24.16.0
+          node-version: 26.2.0
           cache: "npm"
 
       - name: Build

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 24.16.0
+          node-version: 26.2.0
           cache: "npm"
 
       - name: Build

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN echo 2025-01-02 > TODAY
 FROM snapshot-versions-getter-${snapshot_versions_type} as snapshot-versions-getter
 
 
-FROM docker.io/node:24.16.0-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 as caddyfile-builder
+FROM docker.io/node:26.2.0-alpine@sha256:7c6af15abe4e3de859690e7db171d0d711bf37d27528eddfe625b2fe89e097f8 as caddyfile-builder
 
 COPY package.json package-lock.json ./
 RUN npm install -g npm && npm install


### PR DESCRIPTION
## Summary
- Bump Node.js from `24.16.0` to `26.2.0` in the `caddyfile-builder` Dockerfile stage and in the three GitHub Actions workflows (`lint.yml`, `runtime.yml`, `prod_container_img.yml`).
- New image digest: `docker.io/node:26.2.0-alpine@sha256:7c6af15abe4e3de859690e7db171d0d711bf37d27528eddfe625b2fe89e097f8`.

`@types/node` is left at `24.12.4` because no `@types/node@26.x` is published on npm yet (latest is `25.9.1`).

## Test plan
- [ ] CI: `Lint` workflow passes.
- [ ] CI: `Runtime` workflow passes (builds the test image and runs `index.test.ts`).
- [ ] CI: `Production Container Image Builds and Brief Tests` workflow passes (builds the prod image and runs `prod.test.ts`).